### PR TITLE
Custom timeout for Guzzle Client

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -15,7 +15,7 @@ class Api
     public $allow_dynamic_relations = false;
     public string $thumbnail_format = 'png';
 
-    function __construct(string $endpoint, string $token)
+    function __construct(string $endpoint, string $token, float $timeout = 60000)
     {
         if (!preg_match('/^https?:/', $endpoint)) {
             $endpoint = "https://$endpoint.onpage.it/api/";
@@ -25,7 +25,7 @@ class Api
 
         $this->api_url = $endpoint;
         $this->http = new Client([
-            'timeout' => 60000,
+            'timeout' => $timeout,
             'base_uri' => "{$this->api_url}/view/{$token}/",
         ]);
         $this->loadSchema();


### PR DESCRIPTION
It may be useful to set a custom timeout for the Guzzle Client instance used by Api.
In our use case, when using Api inside a Laravel job, we need the http timeout to be lower than the worker timeout.
See [https://github.com/laravel/framework/issues/22301](https://github.com/laravel/framework/issues/22301)